### PR TITLE
n8n: add probe startup grace period

### DIFF
--- a/k8s/disabled/n8n/values.yaml
+++ b/k8s/disabled/n8n/values.yaml
@@ -2,6 +2,23 @@ main:
   count: 1
   editorBaseUrl: "https://n8n.k8s.javydekoning.com"
 
+  # Give n8n time to boot before probes can kill it mid-startup
+  # (seen restart-looping after a powercut/sandbox recreate)
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /healthz/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 6
+
   persistence:
     enabled: true
     volumeName: "n8n-data"


### PR DESCRIPTION
Fixes restart-loop seen after powercut where liveness/readiness probes killed n8n mid-boot before it could come up. Adds initialDelaySeconds=30 and failureThreshold=6 to both probes.